### PR TITLE
Fix: Remove the double quotes from Q_DECLARE_TR_FUNCTIONS

### DIFF
--- a/src/core/metadata/qgslayermetadataformatter.h
+++ b/src/core/metadata/qgslayermetadataformatter.h
@@ -31,7 +31,7 @@
  */
 class CORE_EXPORT QgsLayerMetadataFormatter
 {
-    Q_DECLARE_TR_FUNCTIONS( "QgsLayerMetadataFormatter" )
+    Q_DECLARE_TR_FUNCTIONS( QgsLayerMetadataFormatter )
 
   public:
 


### PR DESCRIPTION
Remove the double quotes

## Description

Q_DECLARE_TR_FUNCTIONS do not need  double quotes
