### PR TITLE
Fixing qgsogrproviderconnection memory leaks

### DIFF
--- a/src/core/providers/ogr/qgsogrproviderconnection.cpp
+++ b/src/core/providers/ogr/qgsogrproviderconnection.cpp
@@ -107,12 +107,6 @@ QVariantList QgsOgrProviderResultIterator::nextRowInternal()
         }
       }
     }
-    else
-    {
-      // Release the resources
-      GDALDatasetReleaseResultSet( mHDS.get(), mOgrLayer );
-      mHDS.reset();
-    }
   }
   return row;
 }

--- a/src/core/providers/ogr/qgsogrproviderconnection.cpp
+++ b/src/core/providers/ogr/qgsogrproviderconnection.cpp
@@ -111,7 +111,7 @@ QVariantList QgsOgrProviderResultIterator::nextRowInternal()
     {
       // Release the resources
       GDALDatasetReleaseResultSet( mHDS.get(), mOgrLayer );
-      mHDS.release();
+      mHDS.reset();
     }
   }
   return row;


### PR DESCRIPTION
## Description

The unique_ptr release function does not free memory
